### PR TITLE
fix dependency specifications

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+cartopy
 flake8
 flake8-builtins
 flake8-comprehensions
@@ -5,9 +6,9 @@ flake8-import-order
 flake8-mutable
 flake8-print
 flake8-quotes
+jupyter
 nbsphinx
+pendulum
 pytest
 sphinx
 xarray
-cartopy
-jupyter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pendulum
 pandas
 requests


### PR DESCRIPTION
Only `pandas` and `requests` are mandatory dependencies.