### PR TITLE
Simplify the erddapy object constructor

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,29 +1,31 @@
-0.1.5
-~~~~~
+# Changelog
+
+## 0.1.6
+
+- Simplify the `erddapy` object constructor.
+  Everything but the `server` and `protocol` should be passed as properties
+  after the object creation.
+
+## 0.1.5
 
 - Re-implemented caching in `get_var_by_attr()`.
 
-0.1.3
-~~~~~
+## 0.1.3
 
 - Avoid a caching bug in `get_var_by_attr()` by not caching at all.
 
-0.1.3
-~~~~~
+## 0.1.3
 
 - New API to make it easier to handle multiple requests from the same server.
 
-0.1.2
-~~~~~
+## 0.1.2
 
 - Added a workaround to access authenticated ERDDAP servers.
 
-0.1.1
-~~~~~
+## 0.1.1
 
 - Mostly boilerplate updates for a GitHub/PyPI release.
 
-0.1.0
-~~~~~
+## 0.1.0
 
 - First version!

--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -79,20 +79,21 @@ class ERDDAP(object):
          'UBC': 'https://salishsea.eos.ubc.ca/erddap'}
 
     """
-    def __init__(self, server, dataset_id=None, protocol=None, variables='',
-                 response='html', constraints=None, params=None, requests_kwargs=None):
+    def __init__(self, server, protocol=None, response='html'):
         if server in servers.keys():
             server = servers[server].url
         self.server = _check_url_response(server)
-        self.dataset_id = dataset_id
         self.protocol = protocol
-        self.variables = variables
-        self.response = response
-        self.constraints = constraints
-        self.params = params
-        self.requests_kwargs = requests_kwargs if requests_kwargs else {}
 
-        # Caching the last `dataset_id` request for quicker multiple accesses,
+        # Initialized only via properties.
+        self.constraints = None
+        self.dataset_id = None
+        self.params = None
+        self.requests_kwargs = {}
+        self.response = response
+        self.variables = ''
+
+        # Caching the last `dataset_id` and `variables` list request for quicker multiple accesses,
         # will be overridden when requesting a new `dataset_id`.
         self._dataset_id = None
         self._variables = {}
@@ -113,7 +114,7 @@ class ERDDAP(object):
         response = response if response else self.response
 
         if not dataset_id:
-            raise ValueError('You must specify a valid dataset_id, got {}'.format(self.dataset_id))
+            raise ValueError(f'You must specify a valid dataset_id, got {dataset_id}')
 
         return info_url(
             server=self.server,
@@ -130,10 +131,10 @@ class ERDDAP(object):
         constraints = constraints if constraints else self.constraints
 
         if not dataset_id:
-            raise ValueError('Please specify a valid `dataset_id`, got {}'.format(self.dataset_id))
+            raise ValueError(f'Please specify a valid `dataset_id`, got {dataset_id}')
 
         if not protocol:
-            raise ValueError('Please specify a valid `protocol`, got {}'.format(self.protocol))
+            raise ValueError(f'Please specify a valid `protocol`, got {protocol}')
 
         return download_url(
             server=self.server,
@@ -196,6 +197,10 @@ class ERDDAP(object):
         """
         if not dataset_id:
             dataset_id = self.dataset_id
+
+        if dataset_id is None:
+            raise ValueError(f'You must specify a valid dataset_id, got {dataset_id}')
+
         url = info_url(self.server, dataset_id=dataset_id, response='csv')
 
         # Creates the variables dictionary for the `get_var_by_attr` lookup.

--- a/notebooks/quick_intro.ipynb
+++ b/notebooks/quick_intro.ipynb
@@ -8,8 +8,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First we need to instantiate the erddapy server object."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from erddapy import ERDDAP\n",
+    "import pandas as pd\n",
+    "\n",
+    "\n",
+    "e = ERDDAP(\n",
+    "    server='https://data.ioos.us/gliders/erddap',\n",
+    "    protocol='tabledap',\n",
+    "    response='csv',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can populate the object with constraints, the variables of interest and the dataset id."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -21,11 +52,9 @@
     }
    ],
    "source": [
-    "from erddapy import ERDDAP\n",
-    "import pandas as pd\n",
+    "e.dataset_id = 'blue-20160818T1448'\n",
     "\n",
-    "\n",
-    "constraints = {\n",
+    "e.constraints = {\n",
     "    'time>=': '2016-07-10T00:00:00Z',\n",
     "    'time<=': '2017-02-10T00:00:00Z',\n",
     "    'latitude>=': 38.0,\n",
@@ -34,31 +63,24 @@
     "    'longitude<=': -69.0,\n",
     "}\n",
     "\n",
-    "variables = [\n",
-    " 'depth',\n",
-    " 'latitude',\n",
-    " 'longitude',\n",
-    " 'salinity',\n",
-    " 'temperature',\n",
-    " 'time',\n",
+    "e.variables = [\n",
+    "    'depth',\n",
+    "    'latitude',\n",
+    "    'longitude',\n",
+    "    'salinity',\n",
+    "    'temperature',\n",
+    "    'time',\n",
     "]\n",
     "\n",
-    "e = ERDDAP(\n",
-    "    server='https://data.ioos.us/gliders/erddap',\n",
-    "    protocol='tabledap',\n",
-    "    response='csv',\n",
-    "    dataset_id='blue-20160818T1448',\n",
-    "    constraints=constraints,\n",
-    "    variables=variables,\n",
-    ")\n",
     "\n",
     "url = e.get_download_url()\n",
+    "\n",
     "print(url)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -152,7 +174,7 @@
        "2016-08-19 17:41:53  10.11  40.997572 -70.953544  32.286210      19.7151"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -169,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -189,7 +211,8 @@
     "import matplotlib.dates as mdates\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(17, 2))\n",
-    "cs = ax.scatter(df.index, df['depth'], s=15, c=df['temperature'], marker='o', edgecolor='none')\n",
+    "cs = ax.scatter(df.index, df['depth'], s=15,\n",
+    "                c=df['temperature'], marker='o', edgecolor='none')\n",
     "\n",
     "ax.invert_yaxis()\n",
     "ax.set_xlim(df.index[0], df.index[-1])\n",
@@ -214,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -255,7 +278,7 @@
        " 'variables']"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -274,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -302,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -323,7 +346,7 @@
        "'We have 432 tabledap, 0 griddap, and 0 wms endpoints.'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -345,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -377,7 +400,7 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -412,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -457,7 +480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -469,7 +492,7 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -489,7 +512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -581,7 +604,7 @@
        "4  Josh Kohut, Dave Aragon, Chip Haldeman, Nicole...  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -596,7 +619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -605,7 +628,7 @@
        "'profile_id, time, latitude, longitude, time_uv, lat_uv, lon_uv, u, v'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -632,15 +655,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 206 ms, sys: 4.5 ms, total: 211 ms\n",
-      "Wall time: 1.69 s\n"
+      "CPU times: user 300 ms, sys: 11.9 ms, total: 312 ms\n",
+      "Wall time: 2.02 s\n"
      ]
     },
     {
@@ -649,7 +672,7 @@
        "['temperature']"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -666,40 +689,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 35.3 ms, sys: 0 ns, total: 35.3 ms\n",
-      "Wall time: 771 ms\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['salinity']"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "%%time\n",
-    "\n",
-    "# Second one on the same glider, fast.\n",
-    "e.get_var_by_attr(\n",
-    "    dataset_id='blue-20160818T1448',\n",
-    "    standard_name='sea_water_practical_salinity'\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 17,
    "metadata": {},
    "outputs": [
@@ -707,8 +696,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 132 ms, sys: 0 ns, total: 132 ms\n",
-      "Wall time: 1.63 s\n"
+      "CPU times: user 21.4 ms, sys: 272 µs, total: 21.6 ms\n",
+      "Wall time: 814 ms\n"
      ]
     },
     {
@@ -718,6 +707,40 @@
       ]
      },
      "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# Second one on the same glider, a little bit faster.\n",
+    "e.get_var_by_attr(\n",
+    "    dataset_id='blue-20160818T1448',\n",
+    "    standard_name='sea_water_practical_salinity'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 154 ms, sys: 16 µs, total: 154 ms\n",
+      "Wall time: 1.44 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['salinity']"
+      ]
+     },
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -741,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -763,7 +786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -803,7 +826,7 @@
        " 'v_qc'}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -825,14 +848,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://data.ioos.us/gliders/erddap/tabledap/allrutgersGliders.html?u,v_qc,density_qc,precise_lon,longitude,conductivity_qc,lon_uv_qc,precise_time_qc,time_uv,time,latitude,density,salinity_qc,lat_uv_qc,temperature,precise_time,latitude_qc,depth,salinity,conductivity,time_qc,pressure,lon_uv,depth_qc,precise_lat,time_uv_qc,v,pressure_qc,u_qc,temperature_qc,longitude_qc,lat_uv&longitude>=-72.0&longitude<=-69.0&latitude>=38.0&latitude<=41.0&time>=1468108800.0&time<=1486684800.0\n"
+      "https://data.ioos.us/gliders/erddap/tabledap/allrutgersGliders.html?temperature_qc,u,v,precise_lon,latitude,pressure_qc,time_qc,lat_uv_qc,salinity,conductivity_qc,u_qc,time_uv_qc,conductivity,time_uv,time,density,lat_uv,longitude,precise_time,v_qc,depth_qc,lon_uv,depth,precise_time_qc,precise_lat,longitude_qc,temperature,salinity_qc,pressure,latitude_qc,lon_uv_qc,density_qc&longitude>=-72.0&longitude<=-69.0&latitude>=38.0&latitude<=41.0&time>=1468108800.0&time<=1486684800.0\n"
      ]
     }
    ],
@@ -867,7 +890,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -919,7 +942,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -942,7 +965,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -993,7 +1016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1034,7 +1057,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -1058,7 +1081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1071,6 +1094,7 @@
    ],
    "source": [
     "from netCDF4 import Dataset\n",
+    "\n",
     "\n",
     "with Dataset(opendap_url) as nc:\n",
     "    print(nc.summary)"
@@ -1088,7 +1112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {
     "scrolled": false
    },
@@ -1104,16 +1128,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'602.93 KB'"
+       "'602.58 KB'"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1145,7 +1169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1154,7 +1178,7 @@
        "'gzip'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1165,7 +1189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {
     "scrolled": true
    },
@@ -1176,40 +1200,40 @@
        "<xarray.Dataset>\n",
        "Dimensions:          (row: 16232)\n",
        "Coordinates:\n",
-       "    longitude        (row) float64 ...\n",
+       "    latitude         (row) float64 ...\n",
        "    time_uv          (row) float64 ...\n",
        "    time             (row) float64 ...\n",
-       "    latitude         (row) float64 ...\n",
-       "    depth            (row) float32 ...\n",
-       "    lon_uv           (row) float64 ...\n",
        "    lat_uv           (row) float64 ...\n",
+       "    longitude        (row) float64 ...\n",
+       "    lon_uv           (row) float64 ...\n",
+       "    depth            (row) float32 ...\n",
        "Dimensions without coordinates: row\n",
        "Data variables:\n",
-       "    u                (row) float64 ...\n",
-       "    v_qc             (row) float32 ...\n",
-       "    density_qc       (row) float32 ...\n",
-       "    precise_lon      (row) float64 ...\n",
-       "    conductivity_qc  (row) float32 ...\n",
-       "    lon_uv_qc        (row) float32 ...\n",
-       "    precise_time_qc  (row) float32 ...\n",
-       "    density          (row) float32 ...\n",
-       "    salinity_qc      (row) float32 ...\n",
-       "    lat_uv_qc        (row) float32 ...\n",
-       "    temperature      (row) float32 ...\n",
-       "    precise_time     (row) float64 ...\n",
-       "    latitude_qc      (row) float32 ...\n",
-       "    salinity         (row) float32 ...\n",
-       "    conductivity     (row) float32 ...\n",
-       "    time_qc          (row) float32 ...\n",
-       "    pressure         (row) float64 ...\n",
-       "    depth_qc         (row) float32 ...\n",
-       "    precise_lat      (row) float64 ...\n",
-       "    time_uv_qc       (row) float32 ...\n",
-       "    v                (row) float64 ...\n",
-       "    pressure_qc      (row) float32 ...\n",
-       "    u_qc             (row) float32 ...\n",
        "    temperature_qc   (row) float32 ...\n",
+       "    u                (row) float64 ...\n",
+       "    v                (row) float64 ...\n",
+       "    precise_lon      (row) float64 ...\n",
+       "    pressure_qc      (row) float32 ...\n",
+       "    time_qc          (row) float32 ...\n",
+       "    lat_uv_qc        (row) float32 ...\n",
+       "    salinity         (row) float32 ...\n",
+       "    conductivity_qc  (row) float32 ...\n",
+       "    u_qc             (row) float32 ...\n",
+       "    time_uv_qc       (row) float32 ...\n",
+       "    conductivity     (row) float32 ...\n",
+       "    density          (row) float32 ...\n",
+       "    precise_time     (row) float64 ...\n",
+       "    v_qc             (row) float32 ...\n",
+       "    depth_qc         (row) float32 ...\n",
+       "    precise_time_qc  (row) float32 ...\n",
+       "    precise_lat      (row) float64 ...\n",
        "    longitude_qc     (row) float32 ...\n",
+       "    temperature      (row) float32 ...\n",
+       "    salinity_qc      (row) float32 ...\n",
+       "    pressure         (row) float64 ...\n",
+       "    latitude_qc      (row) float32 ...\n",
+       "    lon_uv_qc        (row) float32 ...\n",
+       "    density_qc       (row) float32 ...\n",
        "Attributes:\n",
        "    acknowledgement:               Funding provided by the National Science F...\n",
        "    cdm_data_type:                 TrajectoryProfile\n",
@@ -1271,46 +1295,20 @@
        "    Westernmost_Easting:           -71.18259602604894"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "ds = e.to_xarray(decode_times=False)\n",
+    "\n",
     "ds"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "scrolled": true
-   },
-   "source": [
-    "```python\n",
-    "from erddapy.utilities import _urlopen\n",
-    "\n",
-    "\n",
-    "def to_xarray(url, **kw):\n",
-    "    import xarray as xr\n",
-    "    from tempfile import NamedTemporaryFile\n",
-    "    data = _urlopen(url).read()\n",
-    "    with NamedTemporaryFile(suffix='.nc', prefix='erddapy_') as tmp:\n",
-    "        tmp.write(data)\n",
-    "        tmp.flush()\n",
-    "        return xr.open_dataset(tmp.name, **kw)\n",
-    "\n",
-    "ds = to_xarray(\n",
-    "    download_url,\n",
-    ")\n",
-    "\n",
-    "ds\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "metadata": {
     "scrolled": true
    },
@@ -1322,13 +1320,13 @@
        "array([14.3976, 14.4236, 14.4596, ...,  4.4004,  4.3975,  4.3978],\n",
        "      dtype=float32)\n",
        "Coordinates:\n",
-       "    longitude  (row) float64 ...\n",
+       "    latitude   (row) float64 ...\n",
        "    time_uv    (row) float64 ...\n",
        "    time       (row) float64 ...\n",
-       "    latitude   (row) float64 ...\n",
-       "    depth      (row) float32 ...\n",
-       "    lon_uv     (row) float64 ...\n",
        "    lat_uv     (row) float64 ...\n",
+       "    longitude  (row) float64 ...\n",
+       "    lon_uv     (row) float64 ...\n",
+       "    depth      (row) float32 ...\n",
        "Dimensions without coordinates: row\n",
        "Attributes:\n",
        "    _ChunkSizes:          1\n",
@@ -1348,7 +1346,7 @@
        "    valid_min:            -5.0"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1359,7 +1357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1371,7 +1369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1383,7 +1381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1402,7 +1400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Everything but the `server` and `protocol` should be passed as properties after the object creation.

Closes #36 

Ping @rsignell-usgs 