### PR TITLE
use csvp to merge units in the column name

### DIFF
--- a/erddapy/erddapy.py
+++ b/erddapy/erddapy.py
@@ -150,8 +150,13 @@ class ERDDAP(object):
 
         Accepts any `pandas.read_csv` keyword arguments.
 
+        This method uses the `.csvp`(1) response for simplicity,
+        please check ERDDAP's documentation for the other csv options available.
+
+        1) Download a ISO-8859-1 .csv file with line 1: name (units). Times are ISO 8601 strings.
+
         """
-        url = self.get_download_url(response='csv')
+        url = self.get_download_url(response='csvp')
         return pd.read_csv(urlopen(url, params=self.params, **self.requests_kwargs), **kw)
 
     def to_xarray(self, **kw):

--- a/notebooks/quick_intro.ipynb
+++ b/notebooks/quick_intro.ipynb
@@ -183,9 +183,8 @@
     "\n",
     "\n",
     "df = e.to_pandas(\n",
-    "    index_col='time',\n",
+    "    index_col='time (UTC)',\n",
     "    parse_dates=True,\n",
-    "    skiprows=(1,)  # units information can be dropped.\n",
     ").dropna()\n",
     "\n",
     "df.head()"
@@ -213,8 +212,8 @@
     "import matplotlib.dates as mdates\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(17, 2))\n",
-    "cs = ax.scatter(df.index, df['depth'], s=15,\n",
-    "                c=df['temperature'], marker='o', edgecolor='none')\n",
+    "cs = ax.scatter(df.index, df['depth (m)'], s=15,\n",
+    "                c=df['temperature (Celcius)'], marker='o', edgecolor='none')\n",
     "\n",
     "ax.invert_yaxis()\n",
     "ax.set_xlim(df.index[0], df.index[-1])\n",
@@ -912,9 +911,8 @@
     "def download_csv(url):\n",
     "    return pd.read_csv(\n",
     "        url,\n",
-    "        index_col='time',\n",
+    "        index_col='time (UTC)',\n",
     "        parse_dates=True,\n",
-    "        skiprows=[1]\n",
     "    )\n",
     "\n",
     "\n",
@@ -1464,7 +1462,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
If I read the docs correctly ERDDAP has 3 Comma Separated Value formats:

- `csv`: with column names in the first row and units on the second
- `csvp`: with both column names and units in the first row
- `csv0` no names/units just data

It looks like the `to_pandas` method should use `csvp` to avoid forcing the user to workaround the second row parsing.