### PR TITLE
Update servers

### DIFF
--- a/erddapy/utilities.py
+++ b/erddapy/utilities.py
@@ -21,67 +21,67 @@ _server = namedtuple('server', ['description', 'url'])
 servers = {
     'MDA': _server(
         'Marine Domain Awareness (MDA) - Italy',
-        'https://bluehub.jrc.ec.europa.eu/erddap'
+        'https://bluehub.jrc.ec.europa.eu/erddap/'
     ),
     'MII': _server(
         'Marine Institute - Ireland',
-        'http://erddap.marine.ie/erddap'
+        'https://erddap.marine.ie/erddap/'
     ),
     'CSCGOM': _server(
         'CoastWatch Caribbean/Gulf of Mexico Node',
-        'http://cwcgom.aoml.noaa.gov/erddap'
+        'http://cwcgom.aoml.noaa.gov/erddap/'
     ),
     'CSWC': _server(
         'CoastWatch West Coast Node',
-        'https://coastwatch.pfeg.noaa.gov/erddap'
+        'https://coastwatch.pfeg.noaa.gov/erddap/'
     ),
     'CeNCOOS': _server(
         'NOAA IOOS CeNCOOS (Central and Northern California Ocean Observing System)',
-        'http://erddap.axiomalaska.com/erddap'
+        'http://erddap.axiomalaska.com/erddap/'
     ),
     'NERACOOS': _server(
         'NOAA IOOS NERACOOS (Northeastern Regional Association of Coastal and Ocean Observing Systems)',
-        'http://www.neracoos.org/erddap'
+        'http://www.neracoos.org/erddap/'
     ),
     'NGDAC': _server(
         'NOAA IOOS NGDAC (National Glider Data Assembly Center)',
-        'http://data.ioos.us/gliders/erddap'
+        'https://data.ioos.us/gliders/erddap/'
     ),
     'PacIOOS': _server(
         'NOAA IOOS PacIOOS (Pacific Islands Ocean Observing System) at the University of Hawaii (UH)',
-        'http://oos.soest.hawaii.edu/erddap'
+        'http://oos.soest.hawaii.edu/erddap/'
     ),
     'SECOORA': _server(
         'NOAA IOOS SECOORA (Southeast Coastal Ocean Observing Regional Association)',
-        'http://erddap.secoora.org/erddap'
+        'http://erddap.secoora.org/erddap/'
     ),
     'NCEI': _server(
         'NOAA NCEI (National Centers for Environmental Information) / NCDDC',
-        'http://ecowatch.ncddc.noaa.gov/erddap'
+        'https://ecowatch.ncddc.noaa.gov/erddap/'
     ),
     'OSMC': _server(
         'NOAA OSMC (Observing System Monitoring Center)',
-        'http://osmc.noaa.gov/erddap'
+        'http://osmc.noaa.gov/erddap/'
     ),
     'UAF': _server(
         'NOAA UAF (Unified Access Framework)',
-        'https://upwell.pfeg.noaa.gov/erddap'
+        'https://upwell.pfeg.noaa.gov/erddap/'
     ),
     'ONC': _server(
         'ONC (Ocean Networks Canada)',
-        'http://dap.onc.uvic.ca/erddap'
+        'http://dap.onc.uvic.ca/erddap/'
     ),
     'BMLSC': _server(
         'UC Davis BML (University of California at Davis, Bodega Marine Laboratory)',
-        'http://bmlsc.ucdavis.edu:8080/erddap'
+        'http://bmlsc.ucdavis.edu:8080/erddap/'
     ),
     'RTECH': _server(
         'R.Tech Engineering',
-        'http://meteo.rtech.fr/erddap'
+        'https://meteo.rtech.fr/erddap/'
     ),
     'IFREMER': _server(
         'French Research Institute for the Exploitation of the Sea',
-        'http://www.ifremer.fr/erddap'
+        'http://www.ifremer.fr/erddap/'
     ),
     'UBC': _server(
         'UBC Earth, Ocean & Atmospheric Sciences SalishSeaCast Project',

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -6,6 +6,7 @@ from erddapy.utilities import (
     _clean_response,
     parse_dates,
     quote_string_constraints,
+    servers,
     urlopen,
 )
 
@@ -43,6 +44,13 @@ def test_urlopen():
     url = 'http://erddap.sensors.ioos.us/erddap/tabledap/'
     ret = urlopen(url)
     isinstance(ret, io.BytesIO)
+
+
+@pytest.mark.web
+def test_servers():
+    for server in servers.values():
+        # Should raise HTTPError if broken, otherwise returns the URL.
+        _check_url_response(server.url) == server.url
 
 
 def test_parse_dates_naive_datetime():


### PR DESCRIPTION
Some servers were updated to the `https` version and others need the `/` to work. This PR fixes the broken ones and add a test to make it easier to stop broken URLs in the future.