### PR TITLE
Cache `_check_url_response`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+- Cache `_check_url_response` results
+
 ## 0.2.0
 
 - Add a `get_categorize_url` method

--- a/erddapy/utilities.py
+++ b/erddapy/utilities.py
@@ -6,6 +6,7 @@ utilities
 from __future__ import (absolute_import, division, print_function)
 
 
+import functools
 import io
 from collections import namedtuple
 from contextlib import contextmanager
@@ -100,9 +101,10 @@ def urlopen(url, params=None, **kwargs):
     return io.BytesIO(requests.get(url, params=params, **kwargs).content)
 
 
-def _check_url_response(url, **kwargs):
+@functools.lru_cache(maxsize=None)
+def _check_url_response(url):
     """Shortcut to `raise_for_status` instead of fetching the whole content."""
-    r = requests.head(url, **kwargs)
+    r = requests.head(url)
     r.raise_for_status()
     return url
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ versionfile_build = erddapy/_version.py
 tag_prefix = v
 parentdir_prefix =
 
-[pytest]
+[tool:pytest]
 flake8-max-line-length = 105
 flake8-ignore =
     docs/* ALL


### PR DESCRIPTION
Caching the `_check_url_response` results with `functools.lru_cache` to avoid hitting the server multiple times when the URL is the same.